### PR TITLE
Allow relative paths

### DIFF
--- a/multiscript/plan/__init__.py
+++ b/multiscript/plan/__init__.py
@@ -48,7 +48,7 @@ class Plan:
         # self.bible_versions is selected for that column. By default we start with two empty version columns.
         self.version_selection: list[list[bool]] = [[], []]
 
-        # TODO: Do better than hard-coding to the word document. Specify in app settings?
+        # TODO: Should there be a setting to specify the default template?
         self._template_path: Path = multiscript.app().default_template_path
         self._output_dir_path: Path = multiscript.app().output_dir_path
         self.config: PlanConfigGroup = PlanConfigGroup()
@@ -61,6 +61,7 @@ class Plan:
     @path.setter
     def path(self, path: Path):
         '''Sets the path of this plan. The path must be absolute.
+        
         If the current template or output directory paths are now in the same parent directory of this plan
         (or a subdirectory), their values are converted to relative paths.'''
         self._path = path

--- a/multiscript/plan/__init__.py
+++ b/multiscript/plan/__init__.py
@@ -63,14 +63,13 @@ class Plan:
         '''Sets the path of this plan. The path must be absolute.
         If the current template or output directory paths are now in the same parent directory of this plan
         (or a subdirectory), their values are converted to relative paths.'''
-        # Save paths that can be relative to this path
-        template_abspath = self.template_abspath
-        output_dir_abspath = self.output_dir_abspath
-        # Update this plan's path
         self._path = path
-        # Recalculate paths that can be relative to this path
-        self.template_path = template_abspath
-        self.output_dir_path = output_dir_abspath
+        if self.template_path.is_absolute():
+            # Set the property to its current value to give an opportunity to make it relative if necessary
+            self.template_path = self.template_path
+        if self.output_dir_path.is_absolute():
+            # Set the property to its current value to give an opportunity to make it relative if necessary
+            self.output_dir_path = self.output_dir_path
 
     @property
     def template_path(self) -> Path:

--- a/multiscript/plan/runner.py
+++ b/multiscript/plan/runner.py
@@ -61,8 +61,8 @@ class PlanRunner:
                     column_version_list.append(all_versions[row_index])
             self._add_version_list(column_version_list)
 
-        self.base_template_path = plan.template_path
-        self.output_dir_path = plan.output_dir_path
+        self.base_template_path = plan.template_abspath
+        self.output_dir_path = plan.output_dir_abspath
 
         for output in multiscript.app().outputs_for_ext(self.base_template_path.suffix):
             self.output_runs[output.long_id] = output.new_output_plan_run(self.plan)
@@ -85,6 +85,7 @@ class PlanRunner:
         return combinations.get_all_version_combos(self.version_cols)
 
     def run(self):
+        self.plan.output_dir_abspath.mkdir(parents=True, exist_ok=True)
         self.calc_total_progress_steps()
         self.load_bible_content()
         self.select_auto_fonts()

--- a/multiscript/sources/getbible_dot_net.py
+++ b/multiscript/sources/getbible_dot_net.py
@@ -47,7 +47,7 @@ class GetBibleDotNetSource(BibleSource):
         
         Return all of the BibleVersions available for this BibleSource.
         '''
-        response = requests.get('https://api.getbible.net/v2/translations.json')
+        response = requests.get('https://api.getbible.net/v2/translations.json', timeout=15)
         resp_dict = response.json()
         versions = []
         for key, vers_dict in resp_dict.items():
@@ -162,11 +162,11 @@ class GetBibleDotNetVersion(BibleVersion):
 
         bible_ranges = bible_range.split(by_chap=True, num_verses=None)
         for indiv_range in bible_ranges:
+            print(indiv_range)
             indiv_range: BibleRange = indiv_range
             url = f'https://api.getbible.net/v2/{self.id}/{book_code}/{indiv_range.start.chap_num}.json'
-            response = requests.get(url)
+            response = requests.get(url, timeout=15)
             resp_dict = response.json()
-            
             for verse_dict in resp_dict['verses']:
                 verse_num = int(verse_dict['verse'])
                 verse_ref = BibleVerse(indiv_range.start.book, indiv_range.start.chap_num, verse_num)

--- a/multiscript/ui/main_window.py
+++ b/multiscript/ui/main_window.py
@@ -308,6 +308,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
     def on_output_dir_show_button_clicked(self, checked):
         if self.plan.output_dir_path is not None:
+            # If the output dir is a relative path that doesn't exist yet, create it.
             if not self.plan.output_dir_path.is_absolute():
                 self.plan.output_dir_abspath.mkdir(parents=True, exist_ok=True)
             if self.plan.output_dir_abspath.exists():

--- a/multiscript/ui/main_window.py
+++ b/multiscript/ui/main_window.py
@@ -303,24 +303,27 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
     #
 
     def on_template_show_button_clicked(self, checked):
-        if self.plan.template_path is not None and self.plan.template_path.exists():
-            launch_file(self.plan.template_path.parent)
+        if self.plan.template_abspath is not None and self.plan.template_abspath.exists():
+            launch_file(self.plan.template_abspath.parent)
 
     def on_output_dir_show_button_clicked(self, checked):
-        if self.plan.output_dir_path is not None and self.plan.output_dir_path.exists():
-            launch_file(self.plan.output_dir_path)
+        if self.plan.output_dir_path is not None:
+            if not self.plan.output_dir_path.is_absolute():
+                self.plan.output_dir_abspath.mkdir(parents=True, exist_ok=True)
+            if self.plan.output_dir_abspath.exists():
+                launch_file(self.plan.output_dir_abspath)
 
     def on_template_browse_button_clicked(self, checked):
         filters = ' '.join([('*' + ext) for ext in multiscript.app().all_accepted_template_exts])
         template_path, selected_filter = QtWidgets.QFileDialog.getOpenFileName(self, self.tr("Select Template"),
-                                                                   str(self.plan.template_path), filters)
+                                                                   str(self.plan.template_abspath), filters)
         if len(template_path) > 0:
             self.plan.template_path = pathlib.Path(template_path)
             self.set_plan_changed()
 
     def on_output_dir_browse_button_clicked(self, checked):
         output_dir_path = QtWidgets.QFileDialog.getExistingDirectory(self, self.tr("Select Destination Folder"),
-                                                                   str(self.plan.output_dir_path))
+                                                                   str(self.plan.output_dir_abspath))
         if len(output_dir_path) > 0:
             self.plan.output_dir_path = pathlib.Path(output_dir_path)
             self.set_plan_changed()
@@ -531,15 +534,17 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                                         len(self.get_all_version_columns()))))
 
         template_path = self.plan.template_path
+        template_abspath = self.plan.template_abspath
         self.templatePathLabel.setText(template_path.name)
         self.templatePathLabel.setToolTip(str(template_path))
-        self.templateIconLabel.setFileIconFromPath(template_path)
+        self.templateIconLabel.setFileIconFromPath(template_abspath)
         self.templateIconLabel.setToolTip(str(template_path))
 
         output_dir_path = self.plan.output_dir_path
+        output_dir_abspath = self.plan.output_dir_abspath
         self.outputDirPathLabel.setText(output_dir_path.name)
         self.outputDirPathLabel.setToolTip(str(output_dir_path))
-        self.outputDirIconLabel.setFileIconFromPath(output_dir_path)
+        self.outputDirIconLabel.setFileIconFromPath(output_dir_abspath)
         self.outputDirIconLabel.setToolTip(str(output_dir_path))
 
     #

--- a/multiscript/util/serialize.py
+++ b/multiscript/util/serialize.py
@@ -18,6 +18,7 @@ from multiscript.sources.base import BibleSource, SourceAppConfig, SourcePlanCon
 from multiscript.outputs.base import BibleOutput, OutputVersionConfig, OutputAppConfig, OutputPlanConfig
 from multiscript.util.exception import MultiscriptException
 
+
 _logger = logging.getLogger(__name__)
 
 APP_VERSION_KEY         = "app_version"
@@ -186,7 +187,7 @@ def _serialize(orig_obj, output_dict):
         output_dict["__path__"] = str(orig_obj)
     elif isinstance(orig_obj, Plan):
         obj_type = "Plan"
-        del output_dict["path"]
+        del output_dict["_path"]
         del output_dict["changed"]
         del output_dict["new"]
         del output_dict["_orig_path"]
@@ -280,6 +281,18 @@ def _deserialize(file_app_version, error_list, obj_type, input_dict):
 
     elif obj_type == "Plan":
         new_obj = Plan()
+
+        if file_app_version < semver.VersionInfo.parse("0.17.0"):
+            try:
+                input_dict["_template_path"] = input_dict["template_path"]
+                del input_dict["template_path"]
+            except Exception:
+                _logger.info(f"Plan version<0.17.0: Didn't find template_path")
+            try:
+                input_dict["_output_dir_path"] = input_dict["output_dir_path"]
+                del input_dict["output_dir_path"]
+            except Exception:
+                _logger.info(f"Plan version<0.17.0: Didn't find output_dir_path")
 
     elif obj_type == "BibleSource":
         try:

--- a/test/data/integration/plan/test_plan_objects_not_found/test_plan_objects_not_found_expected.mplan
+++ b/test/data/integration/plan/test_plan_objects_not_found/test_plan_objects_not_found_expected.mplan
@@ -227,11 +227,11 @@
                 true
             ]
         ],
-        "template_path": {
+        "_template_path": {
             "__type__": "Path",
             "__path__": "."
         },
-        "output_dir_path": {
+        "_output_dir_path": {
             "__type__": "Path",
             "__path__": "."
         },

--- a/test/unit/plan/test_plan.py
+++ b/test/unit/plan/test_plan.py
@@ -1,0 +1,54 @@
+import unittest
+from pathlib import Path
+
+import multiscript.plan
+
+
+class TestPlan(unittest.TestCase):
+    def test_paths(self):
+        plan = multiscript.plan.Plan()
+
+        # Test absolute paths correctly become relative
+        plan.path = Path("/Path/To/Plan/plan.mplan")
+        plan.template_path = Path("/Path/To/Plan/Templates/template.txt")
+        plan.output_dir_path = Path("/Path/To/Plan/Output/")
+        self.assertEqual(plan.template_path, Path("Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, Path("Output"))
+
+        # Test absolute paths correctly stay absolute
+        plan.template_path = Path("/Path/To/Somewhere/Else/Templates/template.txt")
+        plan.output_dir_path = Path("/Path/To/Somewhere/Else/Output/")
+        self.assertEqual(plan.template_path, Path("/Path/To/Somewhere/Else/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, Path("/Path/To/Somewhere/Else/Output/"))
+
+        # Test relative paths stay relative
+        plan.template_path = Path("Templates/template.txt")
+        plan.output_dir_path = Path("Output")
+        self.assertEqual(plan.template_path, Path("Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, Path("Output"))
+
+        # Test absolute paths calculated correctly
+        plan.path = Path("/Path/To/Plan/plan.mplan")
+        plan.template_path = Path("Templates/template.txt")
+        plan.output_dir_path = Path("Output")
+        self.assertEqual(plan.template_abspath, Path("/Path/To/Plan/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_abspath, Path("/Path/To/Plan/Output"))
+        plan.path = Path("/Path/To/Somewhere/Else/plan.mplan")
+        self.assertEqual(plan.template_abspath, Path("/Path/To/Somewhere/Else/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_abspath, Path("/Path/To/Somewhere/Else/Output"))
+
+        # Test moving the plan recalcuates paths correctly
+        plan.path = Path("/Path/To/Plan/plan.mplan")
+        plan.template_path = Path("/Path/To/Somewhere/Else/Templates/template.txt")
+        plan.output_dir_path = Path("/Path/To/Somewhere/Else/Output/")
+        self.assertEqual(plan.template_path, Path("/Path/To/Somewhere/Else/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, Path("/Path/To/Somewhere/Else/Output/"))
+        plan.path = Path("/Path/To/Different/Location/plan.mplan")
+        self.assertEqual(plan.template_path, Path("/Path/To/Somewhere/Else/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, Path("/Path/To/Somewhere/Else/Output/"))
+        plan.path = Path("/Path/To/Somewhere/Else/plan.mplan")
+        self.assertEqual(plan.template_path, Path("Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, Path("Output"))
+
+
+

--- a/test/unit/plan/test_plan.py
+++ b/test/unit/plan/test_plan.py
@@ -1,25 +1,33 @@
 import unittest
 from pathlib import Path
+import platform
 
 import multiscript.plan
 
 
 class TestPlan(unittest.TestCase):
+
+    def abs_path(self, str_or_path):
+        if platform.system() == "Windows":
+            return Path("C:", str_or_path)
+        else:
+            return Path(str_or_path)
+
     def test_paths(self):
         plan = multiscript.plan.Plan()
 
         # Test absolute paths correctly become relative
-        plan.path = Path("/Path/To/Plan/plan.mplan")
-        plan.template_path = Path("/Path/To/Plan/Templates/template.txt")
-        plan.output_dir_path = Path("/Path/To/Plan/Output/")
+        plan.path = self.abs_path("/Path/To/Plan/plan.mplan")
+        plan.template_path = self.abs_path("/Path/To/Plan/Templates/template.txt")
+        plan.output_dir_path = self.abs_path("/Path/To/Plan/Output/")
         self.assertEqual(plan.template_path, Path("Templates/template.txt"))
         self.assertEqual(plan.output_dir_path, Path("Output"))
 
         # Test absolute paths correctly stay absolute
-        plan.template_path = Path("/Path/To/Somewhere/Else/Templates/template.txt")
-        plan.output_dir_path = Path("/Path/To/Somewhere/Else/Output/")
-        self.assertEqual(plan.template_path, Path("/Path/To/Somewhere/Else/Templates/template.txt"))
-        self.assertEqual(plan.output_dir_path, Path("/Path/To/Somewhere/Else/Output/"))
+        plan.template_path = self.abs_path("/Path/To/Somewhere/Else/Templates/template.txt")
+        plan.output_dir_path = self.abs_path("/Path/To/Somewhere/Else/Output/")
+        self.assertEqual(plan.template_path, self.abs_path("/Path/To/Somewhere/Else/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, self.abs_path("/Path/To/Somewhere/Else/Output/"))
 
         # Test relative paths stay relative
         plan.template_path = Path("Templates/template.txt")
@@ -28,25 +36,25 @@ class TestPlan(unittest.TestCase):
         self.assertEqual(plan.output_dir_path, Path("Output"))
 
         # Test absolute paths calculated correctly
-        plan.path = Path("/Path/To/Plan/plan.mplan")
+        plan.path = self.abs_path("/Path/To/Plan/plan.mplan")
         plan.template_path = Path("Templates/template.txt")
         plan.output_dir_path = Path("Output")
-        self.assertEqual(plan.template_abspath, Path("/Path/To/Plan/Templates/template.txt"))
-        self.assertEqual(plan.output_dir_abspath, Path("/Path/To/Plan/Output"))
-        plan.path = Path("/Path/To/Somewhere/Else/plan.mplan")
-        self.assertEqual(plan.template_abspath, Path("/Path/To/Somewhere/Else/Templates/template.txt"))
-        self.assertEqual(plan.output_dir_abspath, Path("/Path/To/Somewhere/Else/Output"))
+        self.assertEqual(plan.template_abspath, self.abs_path("/Path/To/Plan/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_abspath, self.abs_path("/Path/To/Plan/Output"))
+        plan.path = self.abs_path("/Path/To/Somewhere/Else/plan.mplan")
+        self.assertEqual(plan.template_abspath, self.abs_path("/Path/To/Somewhere/Else/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_abspath, self.abs_path("/Path/To/Somewhere/Else/Output"))
 
         # Test moving the plan recalcuates paths correctly
-        plan.path = Path("/Path/To/Plan/plan.mplan")
-        plan.template_path = Path("/Path/To/Somewhere/Else/Templates/template.txt")
-        plan.output_dir_path = Path("/Path/To/Somewhere/Else/Output/")
-        self.assertEqual(plan.template_path, Path("/Path/To/Somewhere/Else/Templates/template.txt"))
-        self.assertEqual(plan.output_dir_path, Path("/Path/To/Somewhere/Else/Output/"))
-        plan.path = Path("/Path/To/Different/Location/plan.mplan")
-        self.assertEqual(plan.template_path, Path("/Path/To/Somewhere/Else/Templates/template.txt"))
-        self.assertEqual(plan.output_dir_path, Path("/Path/To/Somewhere/Else/Output/"))
-        plan.path = Path("/Path/To/Somewhere/Else/plan.mplan")
+        plan.path = self.abs_path("/Path/To/Plan/plan.mplan")
+        plan.template_path = self.abs_path("/Path/To/Somewhere/Else/Templates/template.txt")
+        plan.output_dir_path = self.abs_path("/Path/To/Somewhere/Else/Output/")
+        self.assertEqual(plan.template_path, self.abs_path("/Path/To/Somewhere/Else/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, self.abs_path("/Path/To/Somewhere/Else/Output/"))
+        plan.path = self.abs_path("/Path/To/Different/Location/plan.mplan")
+        self.assertEqual(plan.template_path, self.abs_path("/Path/To/Somewhere/Else/Templates/template.txt"))
+        self.assertEqual(plan.output_dir_path, self.abs_path("/Path/To/Somewhere/Else/Output/"))
+        plan.path = self.abs_path("/Path/To/Somewhere/Else/plan.mplan")
         self.assertEqual(plan.template_path, Path("Templates/template.txt"))
         self.assertEqual(plan.output_dir_path, Path("Output"))
 


### PR DESCRIPTION
Allows the plan template and output directory to be stored as relative paths, if they are within the same parent directory as the plan (or a subdirectory).